### PR TITLE
fix(basic-resolvers): fix method name mismatch

### DIFF
--- a/docs/basics-resolvers.md
+++ b/docs/basics-resolvers.md
@@ -191,7 +191,7 @@ AuthorTC.wrapResolverAs('findManyReduced', 'findMany', newResolver => {
   // for new created resolver, clone its `filter` argument with a new name
   newResolver.cloneArg('filter', 'AuthorFilterForUsers');
   // remove some filter fields to which regular users should not have access
-  newResolver.getArgTC('filter').removeFields(['age', 'other_sensetive_filter']);
+  newResolver.getArgTC('filter').removeField(['age', 'other_sensetive_filter']);
   // and return modified resolver with new set of args
   return newResolver;
 });


### PR DESCRIPTION
at implementation level, we have a `removeField` method on InputTC, here it references a `removeFields`

[See Here](https://github.com/graphql-compose/graphql-compose/blob/6142100dbcbb1903d2f5f1729bae34cdd89d3f15/src/InputTypeComposer.js#L226)